### PR TITLE
Add directory filtering functionality to rptree

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,16 @@ FLAGS:
 
 OPTIONS:
     -c, --color <color>      Prints color, only supports green, blue and red
+    -f, --filter <filter>... Exclude specific directories and their children from the tree
     -o, --output <output>    Prints to file
 
 ARGS:
     <ROOT_DIR>    Root dir for generate directory tree
 ```
+
+## Examples
+`rptree . --color red --filter target .git`
+In this example, the 'target' directory and the '.git' directory, and all of their children, will be excluded from the tree which will be built from the current directory
 
 ## Reference
 * https://pypi.org/project/rptree/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@ pub mod opt;
 /// Run the program.
 pub fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
     let mut tree_generator = TreeGenerator::new(config.dir_only());
-    tree_generator.build_tree(config.get_root_dir())?;
+    tree_generator.build_tree(config.get_root_dir(), config.get_filter())?;
+
 
     if let Some(file_name) = config.get_output_file() {
         output_to_file(File::create(file_name)?, tree_generator.get_trees())?;

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -21,7 +21,12 @@ pub struct Config {
     /// Root dir for generate directory tree
     #[structopt(name = "ROOT_DIR", parse(from_os_str))]
     root_dir: PathBuf,
-}
+
+    /// Directories to be filtered out
+    #[structopt(short = "f", long = "filter", use_delimiter = true)]
+    filter: Vec<String>,
+
+    }
 
 impl Config {
     pub fn is_root_dir(&self) -> bool {
@@ -47,4 +52,10 @@ impl Config {
             None
         }
     }
+
+    pub fn get_filter(&self) -> &Vec<String> {
+        &self.filter
+    }
+
+    
 }


### PR DESCRIPTION
This pull request adds the functionality to filter specific directories when generating a directory tree using the rptree command-line tool. The changes center around an added `--filter` option to the command-line arguments, which accepts one or more directory names to be filtered out. Also made the necessary changes to 


This new feature allows users to generate directory trees that exclude specific directories, making it easier to focus on relevant parts of the file structure (omitting directories like .git, build, target, etc). Please review the changes and let me know if any modifications are required. Thank you!
